### PR TITLE
Fixes error at startup

### DIFF
--- a/forms.maincomputergui.dfm
+++ b/forms.maincomputergui.dfm
@@ -765,10 +765,6 @@ object MainComputerGUI: TMainComputerGUI
     Top = 711
     Width = 253
     Height = 30
-    AutoOpen = True
-    FileName = 
-      'C:\vms_share\delphicon_2021\ianbarker\spacecomputer\sounds\engag' +
-      'e.mp3'
     Visible = False
     TabOrder = 0
   end


### PR DESCRIPTION
mediaPlayer1 had a hardcoded file name and was set to AutoOpen which lead to an error on startup.
See issue #1